### PR TITLE
[FEATURE] 동문관 카드 겹치는 ui 수정

### DIFF
--- a/src/app/alumni/components/ManyBookmark.tsx
+++ b/src/app/alumni/components/ManyBookmark.tsx
@@ -24,7 +24,6 @@ const ManyBookmark = () => {
 
   useEffect(() => {}, [page]);
 
-  //수정예정
   const token = getToken();
 
   if (!token) {
@@ -85,7 +84,6 @@ const ManyBookmark = () => {
           <ArrayButton />
         </div>
 
-        {/* 모바일 */}
         <Toggle
           checked={showClosed}
           onChange={setShowClosed}
@@ -94,12 +92,12 @@ const ManyBookmark = () => {
         />
       </div>
 
-      <div className="mt-4 grid grid-cols-1 gap-4 md:mt-8 md:grid-cols-2 md:gap-x-4 md:gap-y-6">
+      <div className="mx-auto mt-4 grid w-full grid-cols-1 items-start gap-4 md:mt-8 md:grid-cols-2 md:gap-6">
         {items.map((scrap) => (
           <div
             key={scrap.postingId}
             onClick={() => router.push(`/recruitment/${scrap.postingId}`)}
-            className="border-base-neutral-border flex cursor-pointer rounded-[12px] border bg-white md:w-[592px]"
+            className="border-base-neutral-border flex w-full cursor-pointer rounded-[12px] border bg-white md:h-[164px]"
           >
             <div className="flex min-w-0 flex-1 items-center gap-[10px] px-2 py-4 md:gap-4 md:p-4">
               <div className="border-base-neutral-border relative h-[44px] w-[44px] overflow-hidden rounded-[12px] border bg-gray-50 md:h-[80px] md:w-[80px]">
@@ -107,16 +105,15 @@ const ManyBookmark = () => {
                   src={scrap.companyImageUrl || '/images/sampleimage.png'}
                   alt={`${scrap.companyName} logo`}
                   fill
-                  sizes="(min-width: 768px) 80px, 44px"
                   className="object-contain"
                 />
               </div>
 
-              <div className="flex min-w-0 flex-1 flex-col">
-                <div className="text-contents-neutral-tertiary md:web-summary mobile-summary">
+              <div className="flex min-w-0 flex-1 flex-col bg-white px-5 text-left">
+                <div className="text-contents-neutral-tertiary md:web-summary mobile-summary truncate">
                   {scrap.companyName}
                 </div>
-                <div className="text-contents-neutral-primary mobile-title2 md:web-title2 mt-[6px] md:mt-3">
+                <div className="text-contents-neutral-primary mobile-title2 md:web-title2 mt-[6px] line-clamp-2 w-full text-ellipsis md:mt-3">
                   {scrap.postingTitle}
                 </div>
                 <div className="mt-[6px] flex flex-row items-center md:mt-3">
@@ -147,7 +144,7 @@ const ManyBookmark = () => {
               </div>
             </div>
 
-            <div className="border-base-neutral-border flex w-12 flex-col self-stretch border-l md:w-[84px]">
+            <div className="border-base-neutral-border flex w-12 flex-col self-stretch rounded-r-[12px] border-l bg-white md:w-[84px]">
               <button
                 aria-label="북마크"
                 className="flex flex-1 cursor-pointer items-center justify-center"


### PR DESCRIPTION
## ✅ PR 유형
어떤 변경 사항이 있었나요?

- [ ] 새로운 기능 추가
- [x] 버그 수정
- [] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

---

## 📝 작업 내용
이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

- 동문관 반응형으로 카드를 줄일때 카드끼리 겹치는 이슈를 발견하여 수정했습니다. 그리고 title이 작아지면 카드도 같이 줄어들어서 그 부분 수정했습니다.

<img width="1256" height="569" alt="image" src="https://github.com/user-attachments/assets/c0c71ec5-5487-4f29-8656-95d5764742e9" />
<img width="1241" height="206" alt="image" src="https://github.com/user-attachments/assets/43b4499a-50f9-483b-8067-0d1bca4aab6b" />


---

## ✏️ 관련 이슈
본인이 작업한 내용이 어떤 Issue Number와 관련이 있는지만 작성해주세요
- resoleves #39 

---

## 🎸 기타 사항 or 추가 코멘트


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Redesigned alumni bookmark list into a responsive, full-width grid.
  * Cards now maintain uniform height on medium+ screens with improved padding and left-aligned content.
  * Titles and company names truncate/line-clamp to prevent text overflow.
  * Action column visually separated with a rounded right edge and white background.
  * Image handling refined to maintain proper scaling.
  * Minor cosmetic cleanups for a cleaner, more consistent UI.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->